### PR TITLE
Add footer row support to GenericTable component

### DIFF
--- a/src/app/components/generic-table/generic-table.component.css
+++ b/src/app/components/generic-table/generic-table.component.css
@@ -31,3 +31,11 @@ tr.selected {
 tr.selected:hover {
   background-color: rgba(25, 118, 210, 0.2);
 }
+
+tr.mat-mdc-footer-row td {
+  font-weight: bold;
+}
+
+tr.mat-mdc-header-row th {
+  font-weight: bold;
+}

--- a/src/app/components/generic-table/generic-table.component.html
+++ b/src/app/components/generic-table/generic-table.component.html
@@ -32,13 +32,20 @@
 
             </td>
             }
+
+            <td mat-footer-cell *matFooterCellDef>
+                {{ column.footerContent ? column.footerContent() : '' }}
+            </td>
         </ng-container>
         }
 
         <tr mat-header-row *matHeaderRowDef="displayedColumnIds()" sticky></tr>
         <tr mat-row *matRowDef="let row; columns: displayedColumnIds();" (click)="onRowClick(row)" [class.selected]="selectedRow === row"></tr>
+        @if (showFooter()) {
+        <tr mat-footer-row *matFooterRowDef="displayedColumnIds()"></tr>
+        }
 
     </table>
 </div>
 
-<mat-paginator [pageSizeOptions]="[10, 25, 50, 100]" showFirstLastButtons aria-label="Wähle Seite der Liste" />
+<mat-paginator [pageSizeOptions]="internalPageSizeOptions()" showFirstLastButtons aria-label="Wähle Seite der Liste" />

--- a/src/app/components/generic-table/generic-table.component.ts
+++ b/src/app/components/generic-table/generic-table.component.ts
@@ -1,5 +1,6 @@
 import {
   Component,
+  computed,
   effect,
   EventEmitter,
   input,
@@ -71,6 +72,23 @@ export class GenericTableComponent<T> {
   pageSize = input<number>(10);
 
   /**
+   * The options for the number of items to display per page.
+   * Defaults to [5, 10, 25, 100] if not provided.
+   */
+  pageSizeOptions = input<number[]>([5, 10, 25, 100]);
+
+  /**
+   * Internal representation of the page size options, ensuring the current page size is included.
+   */
+  internalPageSizeOptions = computed(() => {
+    const options = this.pageSizeOptions();
+    if (!options.includes(this.pageSize())) {
+      return [...options, this.pageSize()].sort((a, b) => a - b);
+    }
+    return options;
+  });
+
+  /**
    * Internal representation of the columns.
    */
   internalColumns = signal<TableColumn[]>([]);
@@ -93,6 +111,10 @@ export class GenericTableComponent<T> {
   @ViewChild(MatSort) sort!: MatSort;
 
   @ViewChild(MatPaginator) paginator!: MatPaginator;
+
+  showFooter = computed(() =>
+    this.internalColumns().some((col) => col.footerContent !== undefined)
+  );
 
   /**
    * Lifecycle hook that is called after the component has been initialized.

--- a/src/app/models/generic-table.ts
+++ b/src/app/models/generic-table.ts
@@ -1,3 +1,4 @@
+import { Signal } from "@angular/core";
 import { MatButtonAppearance } from "@angular/material/button";
 
 
@@ -7,6 +8,7 @@ export interface TableColumn<T = any> {
     isInvisible?: boolean; // When true, column is hidden from display
     isUnsortable?: boolean; // Optional property to make the column unsortable
     action?: (row: T) => void; // Optional action for the column
+    footerContent?: Signal<string | number>; // Optional footer content for the column
 }
 
 export interface TableActionButton {


### PR DESCRIPTION
Introduces the ability to display a footer row in the generic table component. Columns can now define a 'footerContent' property, and the table will render a footer row if any column provides footer content. Also, the paginator's page size options are now configurable and ensure the current page size is always included.

This pull request enhances the `GenericTableComponent` by adding support for custom footer rows and improving pagination options. The main improvements include allowing columns to define footer content, conditionally displaying a footer row, and ensuring the paginator's page size options are always consistent with the current selection. Additionally, footer and header rows are now styled for better readability.

**Footer row support and styling:**

* Added an optional `footerContent` property to the `TableColumn` interface, allowing each column to define custom footer content using a signal. (`src/app/models/generic-table.ts`)
* Updated the table template to render a footer row when at least one column provides footer content. (`src/app/components/generic-table/generic-table.component.html`, `src/app/components/generic-table/generic-table.component.ts`) [[1]](diffhunk://#diff-a1d0cd16bd3633cff9b8deca804e7f5b234fa1da8e755b1954cecc7889ded915R35-R51) [[2]](diffhunk://#diff-659b291e9f5c7c0b266debd27db4f31df3c3e64998028c3cac66ac707233e984R115-R118)
* Applied bold styling to footer and header rows for improved visual distinction. (`src/app/components/generic-table/generic-table.component.css`)

**Pagination improvements:**

* Made the paginator's page size options configurable via an input, with logic to ensure the current page size is always included in the options. (`src/app/components/generic-table/generic-table.component.ts`, `src/app/components/generic-table/generic-table.component.html`) [[1]](diffhunk://#diff-659b291e9f5c7c0b266debd27db4f31df3c3e64998028c3cac66ac707233e984R74-R90) [[2]](diffhunk://#diff-a1d0cd16bd3633cff9b8deca804e7f5b234fa1da8e755b1954cecc7889ded915R35-R51)

**Type and import updates:**

* Added missing import for `Signal` in the table model to support the new `footerContent` property. (`src/app/models/generic-table.ts`)
* Added `computed` import in the component to support new computed properties. (`src/app/components/generic-table/generic-table.component.ts`)