### PR TITLE
fix: update order ID formatting and improve resolver logic for better…

### DIFF
--- a/src/app/pages/order/edit-order-page/edit-order-page.component.ts
+++ b/src/app/pages/order/edit-order-page/edit-order-page.component.ts
@@ -471,7 +471,7 @@ export class EditOrderPageComponent implements OnInit, HasUnsavedChanges, OnDest
 
         this.orderName.set(this.formattedOrderDTO.content_description ?? 'Fehler: Kein Name');
         this.orderBesyId.set(
-          `${this.formattedOrderDTO.primary_cost_center_id?.value}-${this.formattedOrderDTO.booking_year}-${this.formattedOrderDTO.auto_index}`
+          `${this.formattedOrderDTO.primary_cost_center_id?.value}-${this.formattedOrderDTO.booking_year!.slice(-2)}-${this.formattedOrderDTO.auto_index}`
         );
         const loginCredentials = this.userWrapperService.getCurrentUser();
         console.log(loginCredentials);

--- a/src/app/resolver/edit-order-resolver.ts
+++ b/src/app/resolver/edit-order-resolver.ts
@@ -1,13 +1,11 @@
 import { Injectable } from '@angular/core';
-import {
-  ActivatedRouteSnapshot,
-  Resolve,
-  Router,
-  RouterStateSnapshot
-} from '@angular/router';
+import { ActivatedRouteSnapshot, Resolve, Router, RouterStateSnapshot } from '@angular/router';
 import { catchError, EMPTY, from, map, Observable, switchMap } from 'rxjs';
 import { OrderResponseDTO } from '../api-services-v2';
-import { OrderResponseDTOFormatted, OrdersWrapperService } from '../services/wrapper-services/orders-wrapper.service';
+import {
+  OrderResponseDTOFormatted,
+  OrdersWrapperService,
+} from '../services/wrapper-services/orders-wrapper.service';
 
 export interface EditOrderResolvedData {
   order: OrderResponseDTO;
@@ -15,24 +13,41 @@ export interface EditOrderResolvedData {
 }
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class EditOrderResolver implements Resolve<EditOrderResolvedData | null> {
   constructor(
     private readonly router: Router,
-    private readonly ordersService: OrdersWrapperService,
+    private readonly ordersService: OrdersWrapperService
   ) {}
 
-  resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<EditOrderResolvedData | null> {
-    const idParam = route.paramMap.get('id');
-    const id = Number.parseInt(idParam ?? '', 10);
+  resolve(
+    route: ActivatedRouteSnapshot,
+    _state: RouterStateSnapshot
+  ): Observable<EditOrderResolvedData | null> {
+    const id = route.paramMap.get('id');
 
-    if (Number.isNaN(id)) {
+    if (!id) {
       this.router.navigate(['/not-found'], { skipLocationChange: true });
       return EMPTY;
     }
 
-    return from(this.ordersService.getOrderById(id)).pipe(
+    let orderObservable: Observable<OrderResponseDTO>;
+
+    if (id.includes('-')) {
+      // Order number format (e.g., "KST-25-123")
+      orderObservable = from(this.ordersService.getOrderByOrderNumber(id));
+    } else {
+      // Numeric ID format
+      const numericId = Number.parseInt(id, 10);
+      if (Number.isNaN(numericId)) {
+        this.router.navigate(['/not-found'], { skipLocationChange: true });
+        return EMPTY;
+      }
+      orderObservable = from(this.ordersService.getOrderById(numericId));
+    }
+
+    return orderObservable.pipe(
       switchMap(order =>
         from(this.ordersService.mapOrderResponseToFormatted(order)).pipe(
           map(formattedOrder => ({ order, formattedOrder }))


### PR DESCRIPTION
This pull request improves the handling of order identification and formatting in the order editing workflow. The main changes ensure that order numbers with different formats are properly resolved and displayed, enhancing robustness and user experience.

**Order identification and resolution improvements:**

* Updated the `EditOrderResolver` in `src/app/resolver/edit-order-resolver.ts` to support both numeric IDs and formatted order numbers (e.g., "KST-25-123"), selecting the appropriate service method for each format. This prevents errors and allows flexible navigation to orders.

**Order display formatting:**

* Changed the display of the order number in `EditOrderPageComponent` (`src/app/pages/order/edit-order-page/edit-order-page.component.ts`) to show only the last two digits of the booking year, resulting in a more concise and user-friendly format.… error handling