### PR TITLE
Highlight error edit page

### DIFF
--- a/src/app/components/form-component/form-component.component.html
+++ b/src/app/components/form-component/form-component.component.html
@@ -13,7 +13,7 @@
       @switch (field.type) {
         <!-- Textfeld -->
         @case ('text') {
-          <mat-form-field class="w-full">
+          <mat-form-field class="w-full {{ environment.orderFieldClassPrefix + field.name }}">
             <mat-label>{{ field.label }}</mat-label>
             <input matInput [formControlName]="field.name" [required]="field.required" />
             @if (formGroup.get(field.name)?.invalid && formGroup.get(field.name)?.touched) {
@@ -38,7 +38,7 @@
 
         <!-- Select -->
         @case ('select') {
-          <mat-form-field class="w-full">
+          <mat-form-field class="w-full {{ environment.orderFieldClassPrefix + field.name }}">
             <mat-label>{{ field.label }}</mat-label>
             <mat-select [formControlName]="field.name" [required]="field.required">
               @for (opt of field.options ?? []; track opt.value) {
@@ -67,7 +67,7 @@
 
         <!-- Radio -->
         @case ('radio') {
-          <div class="w-full flex flex-col">
+          <div class="w-full flex flex-col {{ environment.orderFieldClassPrefix + field.name }}">
             <!-- Label + Help Icon -->
             <div class="flex items-center mb-2">
               <label class="text-gray-700 text-lg font-medium">
@@ -107,7 +107,11 @@
 
         <!-- Checkbox -->
         @case ('checkbox') {
-          <div class="w-full flex items-center gap-2">
+          <div
+            class="w-full flex items-center gap-2 {{
+              environment.orderFieldClassPrefix + field.name
+            }}"
+          >
             <!-- Checkbox -->
             <mat-checkbox [formControlName]="field.name">
               {{ field.label }}
@@ -136,7 +140,7 @@
 
         <!-- Number -->
         @case ('number') {
-          <mat-form-field class="w-full">
+          <mat-form-field class="w-full {{ environment.orderFieldClassPrefix + field.name }}">
             <mat-label>{{ field.label }}</mat-label>
             <input
               matInput
@@ -166,7 +170,7 @@
 
         <!-- Date -->
         @case ('date') {
-          <mat-form-field class="w-full">
+          <mat-form-field class="w-full {{ environment.orderFieldClassPrefix + field.name }}">
             <mat-label>{{ field.label }}</mat-label>
             <input
               matInput
@@ -199,7 +203,7 @@
 
         <!-- Email -->
         @case ('email') {
-          <mat-form-field class="w-full">
+          <mat-form-field class="w-full {{ environment.orderFieldClassPrefix + field.name }}">
             <mat-label>{{ field.label }}</mat-label>
             <input
               matInput
@@ -227,7 +231,7 @@
           </mat-form-field>
         }
         @case ('tel') {
-          <mat-form-field class="w-full">
+          <mat-form-field class="w-full {{ environment.orderFieldClassPrefix + field.name }}">
             <mat-label>{{ field.label }}</mat-label>
             <input matInput [formControlName]="field.name" [required]="field.required" type="tel" />
             @if (formGroup.get(field.name)?.invalid && formGroup.get(field.name)?.touched) {
@@ -250,7 +254,7 @@
           </mat-form-field>
         }
         @case ('search') {
-          <div class="search-field-container">
+          <div class="search-field-container {{ environment.orderFieldClassPrefix + field.name }}">
             <input
               class="search-input"
               [formControlName]="field.name"
@@ -291,11 +295,12 @@
             [dataSource]="tableDataSource"
             [columns]="tableColumns"
             [pageSize]="5"
+            class="{{ environment.orderFieldClassPrefix + field.name }}"
           ></app-generic-table>
           <mat-divider class="bg-he-lightblue" style="border-top-width: 2px"></mat-divider>
         }
         @case ('textarea') {
-          <mat-form-field class="w-full">
+          <mat-form-field class="w-full {{ environment.orderFieldClassPrefix + field.name }}">
             <mat-label>{{ field.label }}</mat-label>
             <textarea
               matInput
@@ -322,7 +327,7 @@
           </mat-form-field>
         }
         @case ('autocomplete') {
-          <mat-form-field class="w-full">
+          <mat-form-field class="w-full {{ environment.orderFieldClassPrefix + field.name }}">
             <mat-label>{{ field.label }}</mat-label>
 
             <input

--- a/src/app/components/form-component/form-component.component.ts
+++ b/src/app/components/form-component/form-component.component.ts
@@ -23,6 +23,7 @@ import { MatRadioModule } from '@angular/material/radio';
 import { MatSelectModule } from '@angular/material/select';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatTooltip } from '@angular/material/tooltip';
+import { environment } from '../../../environments/environment';
 import { GenericTableComponent } from '../generic-table/generic-table.component';
 
 export interface FormField {
@@ -104,6 +105,8 @@ export interface FormConfig {
 })
 export class FormComponent implements OnInit {
   constructor(private readonly fb: FormBuilder) {}
+
+  protected readonly environment = environment;
 
   @Input() config!: FormConfig;
   @Input() formGroup!: FormGroup;

--- a/src/app/components/toast-invalid-order/toast-invalid-order.component.ts
+++ b/src/app/components/toast-invalid-order/toast-invalid-order.component.ts
@@ -3,12 +3,13 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { RouterModule } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
 import { ZodError } from 'zod';
 import { environment } from '../../../environments/environment';
 import { OrderStatus } from '../../api-services-v2';
 import { ORDER_FIELD_NAMES } from '../../display-name-mappings/order-names';
 import { STATE_DISPLAY_NAMES } from '../../display-name-mappings/status-names';
+import { ORDER_EDIT_TABS_TO_CONIG_MAPPING } from '../../pages/order/edit-order-page/edit-order-page.component';
 import { DriverJsTourService } from '../../services/driver.js-tour.service';
 
 type ToastError = {
@@ -55,14 +56,18 @@ export class ToastInvalidOrderComponent {
     },
   });
 
-  constructor(private readonly driverJsService: DriverJsTourService) {}
+  constructor(private readonly driverJsService: DriverJsTourService, private readonly router: Router) { }
 
   /**
    *  Highlights a specific field in the order form based on the provided ToastError.
    * @param error The ToastError containing field information.
    */
-  highlightField(error: ToastError) {
+  async highlightField(error: ToastError) {
     if (!error.fieldName) return;
+
+    if (this.router.url === `/orders/${this.orderId}/edit`) {
+      await this.switchToTabForField(error.fieldName);
+    }
 
     try {
       const selector = `.${environment.orderFieldClassPrefix}${error.fieldName}`;
@@ -72,5 +77,20 @@ export class ToastInvalidOrderComponent {
     } catch (e) {
       console.error('Fehler beim Hervorheben des Feldes:', e);
     }
+  }
+
+  switchToTabForField(fieldName: string) {
+    const targetTab = Object.entries(ORDER_EDIT_TABS_TO_CONIG_MAPPING).find(
+      ([_, config]) => config.fields.some(
+        field => field.name === fieldName
+      )
+    )?.[0];
+    if (targetTab) {
+      return this.router.navigate([], {
+        queryParams: { tab: targetTab },
+        queryParamsHandling: 'merge',
+      });
+    }
+    return Promise.resolve(false);
   }
 }

--- a/src/app/components/toast-invalid-order/toast-invalid-order.component.ts
+++ b/src/app/components/toast-invalid-order/toast-invalid-order.component.ts
@@ -4,6 +4,7 @@ import { MatDividerModule } from '@angular/material/divider';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { Router, RouterModule } from '@angular/router';
+import { delay, from, of } from 'rxjs';
 import { ZodError } from 'zod';
 import { environment } from '../../../environments/environment';
 import { OrderStatus } from '../../api-services-v2';
@@ -56,41 +57,53 @@ export class ToastInvalidOrderComponent {
     },
   });
 
-  constructor(private readonly driverJsService: DriverJsTourService, private readonly router: Router) { }
+  constructor(
+    private readonly driverJsService: DriverJsTourService,
+    private readonly router: Router
+  ) {}
 
   /**
    *  Highlights a specific field in the order form based on the provided ToastError.
    * @param error The ToastError containing field information.
    */
-  async highlightField(error: ToastError) {
+  highlightField(error: ToastError) {
     if (!error.fieldName) return;
 
-    if (this.router.url === `/orders/${this.orderId}/edit`) {
-      await this.switchToTabForField(error.fieldName);
+    let navigationObservable = of(false);
+
+    if (this.router.url.includes('/orders/') && this.router.url.includes('/edit')) {
+      navigationObservable = this.switchToTabForField(error.fieldName);
     }
 
-    try {
-      const selector = `.${environment.orderFieldClassPrefix}${error.fieldName}`;
-      if (document.querySelector(selector)) {
-        this.driverJsService.highlightElement(selector, 'Fehler beim Statuswechsel', error.message);
+    // Add a small delay to ensure the DOM has updated after navigation before trying to highlight the element
+    navigationObservable.pipe(delay(300)).subscribe(() => {
+      try {
+        const selector = `.${environment.orderFieldClassPrefix}${error.fieldName}`;
+        if (document.querySelector(selector)) {
+          this.driverJsService.highlightElement(
+            selector,
+            'Fehler beim Statuswechsel',
+            error.message
+          );
+        }
+      } catch (e) {
+        console.error('Fehler beim Hervorheben des Feldes:', e);
       }
-    } catch (e) {
-      console.error('Fehler beim Hervorheben des Feldes:', e);
-    }
+    });
   }
 
   switchToTabForField(fieldName: string) {
-    const targetTab = Object.entries(ORDER_EDIT_TABS_TO_CONIG_MAPPING).find(
-      ([_, config]) => config.fields.some(
-        field => field.name === fieldName
-      )
+    const targetTab = Object.entries(ORDER_EDIT_TABS_TO_CONIG_MAPPING).find(([_, configs]) =>
+      configs.some(config => config.fields.some(field => field.name === fieldName))
     )?.[0];
     if (targetTab) {
-      return this.router.navigate([], {
-        queryParams: { tab: targetTab },
-        queryParamsHandling: 'merge',
-      });
+      return from(
+        this.router.navigate([], {
+          queryParams: { tab: targetTab },
+          queryParamsHandling: 'merge',
+        })
+      );
     }
-    return Promise.resolve(false);
+    return of(false);
   }
 }

--- a/src/app/pages/order/edit-order-page/edit-order-page.component.html
+++ b/src/app/pages/order/edit-order-page/edit-order-page.component.html
@@ -265,8 +265,6 @@
             <app-form-component
               [config]="quotationFormConfig"
               [formGroup]="quotationFormGroup"
-              [refreshTrigger]="quotationFormConfigRefreshTrigger()"
-              (valueChanged)="handleQuotationDialogCompanySelection($event)"
             ></app-form-component>
           </mat-dialog-content>
           <mat-dialog-actions align="end">
@@ -317,7 +315,10 @@
             [refreshTrigger]="deliveryPersonConfigRefreshTrigger()"
           ></app-form-component>
         </div>
-        <div class="delivery-address-container mt-4">
+        <div
+          class="delivery-address-container mt-4"
+          [class]="`${environment.orderFieldClassPrefix}delivery_address_id`"
+        >
           @if (isTabEditable('Addresses')) {
             <mat-button-toggle-group
               name="deliveryAddressOptions"
@@ -399,7 +400,10 @@
           }
           <!-- Rechnungsadresse -->
           @if (!sameAsRecipient && selectedDeliveryPerson) {
-            <div class="invoice-address-container mt-4">
+            <div
+              class="invoice-address-container mt-4"
+              [class]="`${environment.orderFieldClassPrefix}invoice_address_id`"
+            >
               <app-form-component
                 [config]="invoicePersonFormConfig"
                 [formGroup]="invoicePersonFormGroup"

--- a/src/app/pages/order/edit-order-page/edit-order-page.component.ts
+++ b/src/app/pages/order/edit-order-page/edit-order-page.component.ts
@@ -123,6 +123,15 @@ export const ORDER_EDIT_TABS = [
   'Approvals',
 ] as const;
 
+export const ORDER_EDIT_TABS_TO_CONIG_MAPPING: Record<(typeof ORDER_EDIT_TABS)[number], FormConfig> = {
+  General: ORDER_GENERAL_FORM_CONFIG,
+  MainOffer: ORDER_MAIN_OFFER_FORM_CONFIG,
+  Items: ORDER_ITEM_FORM_CONFIG,
+  Quotations: ORDER_QUOTATION_FORM_CONFIG,
+  Addresses: ORDER_ADDRESS_FORM_CONFIG,
+  Approvals: ORDER_APPROVAL_FORM_CONFIG,
+};
+
 /**
  * Model for the quotations table used in the order edit/create page
  */

--- a/src/app/pages/order/edit-order-page/edit-order-page.component.ts
+++ b/src/app/pages/order/edit-order-page/edit-order-page.component.ts
@@ -34,6 +34,7 @@ import { MatTableDataSource } from '@angular/material/table';
 import { MatTabGroup, MatTabsModule } from '@angular/material/tabs';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { first, Subscription } from 'rxjs';
+import { environment } from '../../../../environments/environment';
 import {
   AddressRequestDTO,
   AddressResponseDTO,
@@ -123,13 +124,26 @@ export const ORDER_EDIT_TABS = [
   'Approvals',
 ] as const;
 
-export const ORDER_EDIT_TABS_TO_CONIG_MAPPING: Record<(typeof ORDER_EDIT_TABS)[number], FormConfig> = {
-  General: ORDER_GENERAL_FORM_CONFIG,
-  MainOffer: ORDER_MAIN_OFFER_FORM_CONFIG,
-  Items: ORDER_ITEM_FORM_CONFIG,
-  Quotations: ORDER_QUOTATION_FORM_CONFIG,
-  Addresses: ORDER_ADDRESS_FORM_CONFIG,
-  Approvals: ORDER_APPROVAL_FORM_CONFIG,
+export const ORDER_EDIT_TABS_TO_CONIG_MAPPING: Record<
+  (typeof ORDER_EDIT_TABS)[number],
+  FormConfig[]
+> = {
+  General: [
+    ORDER_GENERAL_FORM_CONFIG,
+    ORDER_PRIMARY_COST_CENTER_FORM_CONFIG,
+    ORDER_SECONDARY_COST_CENTER_FORM_CONFIG,
+    ORDER_QUERIES_PERSON_FORM_CONFIG,
+  ],
+  MainOffer: [ORDER_MAIN_OFFER_FORM_CONFIG, ORDER_SUPPLIER_DECISION_REASON_FORM_CONFIG],
+  Items: [ORDER_ITEM_FORM_CONFIG],
+  Quotations: [ORDER_QUOTATION_FORM_CONFIG],
+  Addresses: [
+    ORDER_ADDRESS_FORM_CONFIG,
+    ORDER_DELIVERY_PERSON_FORM_CONFIG,
+    ORDER_INVOICE_PERSON_FORM_CONFIG,
+    { fields: [{ name: 'delivery_address_id' }, { name: 'invoice_address_id' }] } as FormConfig,
+  ],
+  Approvals: [ORDER_APPROVAL_FORM_CONFIG],
 };
 
 /**
@@ -190,6 +204,8 @@ export class EditOrderPageComponent implements OnInit, HasUnsavedChanges, OnDest
   @ViewChild('addQuotationDialog')
   private readonly addQuotationDialogTemplate?: TemplateRef<unknown>;
   private addQuotationDialogRef?: MatDialogRef<unknown>;
+
+  protected readonly environment = environment;
 
   constructor(
     private readonly router: Router,
@@ -518,7 +534,6 @@ export class EditOrderPageComponent implements OnInit, HasUnsavedChanges, OnDest
         this.orderBesyId.set(
           `${this.formattedOrderDTO.primary_cost_center_id?.value}-${this.formattedOrderDTO.booking_year!.slice(-2)}-${this.formattedOrderDTO.auto_index}`
         );
-        const loginCredentials = this.userWrapperService.getCurrentUser();
       });
     });
     this.registerTourSteps();
@@ -1595,7 +1610,7 @@ export class EditOrderPageComponent implements OnInit, HasUnsavedChanges, OnDest
       (this.formattedOrderDTO.invoice_person_id &&
         this.formattedOrderDTO.delivery_person_id &&
         this.formattedOrderDTO.invoice_person_id.value !==
-        this.formattedOrderDTO.delivery_person_id.value) ||
+          this.formattedOrderDTO.delivery_person_id.value) ||
       (this.formattedOrderDTO.invoice_address_id &&
         this.formattedOrderDTO.invoice_address_id !== this.formattedOrderDTO.delivery_address_id)
     ) {
@@ -1791,7 +1806,8 @@ export class EditOrderPageComponent implements OnInit, HasUnsavedChanges, OnDest
       .filter(item => !item.item_id)
       .map(item => this.orderWrapperService.mapItemTableModelToItemRequestDTO(item));
 
-    this.additionalChangesMade = this.additionalChangesMade || itemsToCreate.length > 0 || this.itemsToDelete.size > 0;
+    this.additionalChangesMade =
+      this.additionalChangesMade || itemsToCreate.length > 0 || this.itemsToDelete.size > 0;
 
     // create all new items if any got added
     if (itemsToCreate.length > 0) {
@@ -1854,7 +1870,10 @@ export class EditOrderPageComponent implements OnInit, HasUnsavedChanges, OnDest
       .map(quotation =>
         this.orderWrapperService.mapQuotationTableModelToQuotationRequestDTO(quotation)
       );
-    this.additionalChangesMade = this.additionalChangesMade || quotationsToCreate.length > 0 || this.quotationsToDelete.size > 0;
+    this.additionalChangesMade =
+      this.additionalChangesMade ||
+      quotationsToCreate.length > 0 ||
+      this.quotationsToDelete.size > 0;
     // create all new quotations if any got added
     if (quotationsToCreate.length > 0) {
       try {
@@ -2071,28 +2090,28 @@ export class EditOrderPageComponent implements OnInit, HasUnsavedChanges, OnDest
     string,
     { tabName: string; configs: FormConfig[] }
   > = {
-      General: {
-        tabName: 'Allgemeine Angaben',
-        configs: [
-          this.generalFormConfig,
-          this.queriesPersonFormConfig,
-          this.primaryCostCenterFormConfig,
-          this.secondaryCostCenterFormConfig,
-        ],
-      },
-      MainOffer: {
-        tabName: 'Hauptangebot',
-        configs: [this.mainOfferFormConfig, this.supplierDecisionReasonFormConfig],
-      },
-      Addresses: {
-        tabName: 'Adressdaten',
-        configs: [this.deliveryPersonFormConfig, this.invoicePersonFormConfig],
-      },
-      Approvals: {
-        tabName: 'Genehmigungen',
-        configs: [this.approvalFormConfig],
-      },
-    };
+    General: {
+      tabName: 'Allgemeine Angaben',
+      configs: [
+        this.generalFormConfig,
+        this.queriesPersonFormConfig,
+        this.primaryCostCenterFormConfig,
+        this.secondaryCostCenterFormConfig,
+      ],
+    },
+    MainOffer: {
+      tabName: 'Hauptangebot',
+      configs: [this.mainOfferFormConfig, this.supplierDecisionReasonFormConfig],
+    },
+    Addresses: {
+      tabName: 'Adressdaten',
+      configs: [this.deliveryPersonFormConfig, this.invoicePersonFormConfig],
+    },
+    Approvals: {
+      tabName: 'Genehmigungen',
+      configs: [this.approvalFormConfig],
+    },
+  };
 
   /**
    * Checks if there are unsaved changes in the form.


### PR DESCRIPTION
This pull request introduces improvements to how form fields are identified and highlighted throughout the order editing workflow. The main change is the consistent application of a CSS class prefix (from the environment config) to form field containers and inputs, enabling more reliable field targeting for UI interactions such as error highlighting. Additionally, logic was added to automatically switch tabs in the order editing UI when highlighting a field that may be on a different tab.

**Form field identification and highlighting improvements:**

* Added `environment.orderFieldClassPrefix` to the CSS classes of all major form field containers and inputs in `form-component.component.html`, ensuring each field can be uniquely targeted for highlighting and other UI operations. [[1]](diffhunk://#diff-61f51ccb78c2dcb2009596e74713fee9a370312786c4a90ec05f724b6d266a1bL16-R16) [[2]](diffhunk://#diff-61f51ccb78c2dcb2009596e74713fee9a370312786c4a90ec05f724b6d266a1bL41-R41) [[3]](diffhunk://#diff-61f51ccb78c2dcb2009596e74713fee9a370312786c4a90ec05f724b6d266a1bL70-R70) [[4]](diffhunk://#diff-61f51ccb78c2dcb2009596e74713fee9a370312786c4a90ec05f724b6d266a1bL110-R114) [[5]](diffhunk://#diff-61f51ccb78c2dcb2009596e74713fee9a370312786c4a90ec05f724b6d266a1bL139-R143) [[6]](diffhunk://#diff-61f51ccb78c2dcb2009596e74713fee9a370312786c4a90ec05f724b6d266a1bL169-R173) [[7]](diffhunk://#diff-61f51ccb78c2dcb2009596e74713fee9a370312786c4a90ec05f724b6d266a1bL202-R206) [[8]](diffhunk://#diff-61f51ccb78c2dcb2009596e74713fee9a370312786c4a90ec05f724b6d266a1bL230-R234) [[9]](diffhunk://#diff-61f51ccb78c2dcb2009596e74713fee9a370312786c4a90ec05f724b6d266a1bL253-R257) [[10]](diffhunk://#diff-61f51ccb78c2dcb2009596e74713fee9a370312786c4a90ec05f724b6d266a1bR298-R303) [[11]](diffhunk://#diff-61f51ccb78c2dcb2009596e74713fee9a370312786c4a90ec05f724b6d266a1bL325-R330)
* Exposed the `environment` object to the `FormComponent` and `EditOrderPageComponent` classes to enable use of the prefix in templates and logic. [[1]](diffhunk://#diff-5dc9557f1ae90307a855689467a65ef810981f219e9e7ca9f2dd782d58f0fbefR26) [[2]](diffhunk://#diff-5dc9557f1ae90307a855689467a65ef810981f219e9e7ca9f2dd782d58f0fbefR109-R110) [[3]](diffhunk://#diff-342073939feece0330b830e30ab03ac5de05ff75ba7e3ade1bb10635094a38a5R37) [[4]](diffhunk://#diff-342073939feece0330b830e30ab03ac5de05ff75ba7e3ade1bb10635094a38a5R208-R209)

**Error highlighting and navigation logic:**

* Enhanced the error highlighting logic in `toast-invalid-order.component.ts` to automatically switch to the correct tab for a field before highlighting it, using a mapping of tabs to form configs. This ensures users are navigated to the relevant section before the field is highlighted. [[1]](diffhunk://#diff-ef55278c2ba1fdceebf0972e6514b5e9551699667f9cac8eeca74cfda6a29e62L6-R13) [[2]](diffhunk://#diff-ef55278c2ba1fdceebf0972e6514b5e9551699667f9cac8eeca74cfda6a29e62L58-R63) [[3]](diffhunk://#diff-ef55278c2ba1fdceebf0972e6514b5e9551699667f9cac8eeca74cfda6a29e62R72-R107) [[4]](diffhunk://#diff-342073939feece0330b830e30ab03ac5de05ff75ba7e3ade1bb10635094a38a5R127-R148)
* Added the `ORDER_EDIT_TABS_TO_CONIG_MAPPING` to map each tab to its corresponding form configs and fields, supporting the automatic tab switching feature.

**Template updates for address sections:**

* Updated the address section containers in `edit-order-page.component.html` to use the new field class prefix for delivery and invoice addresses, further supporting targeted UI interactions. [[1]](diffhunk://#diff-38eeda5131e4c822f64b209b60386641029ac221a2e5f4c84a66131675d480f2L320-R321) [[2]](diffhunk://#diff-38eeda5131e4c822f64b209b60386641029ac221a2e5f4c84a66131675d480f2L402-R406)

These changes collectively improve the robustness and usability of field-level error feedback and navigation in the order editing UI.