### PR TITLE
Add display for legacy invoices

### DIFF
--- a/src/app/components/order-display/legacy-invoice-display/legacy-invoice-display.component.html
+++ b/src/app/components/order-display/legacy-invoice-display/legacy-invoice-display.component.html
@@ -1,0 +1,6 @@
+@if (!isEmpty()) {
+  <div class="flex flex-col gap-4">
+    <h4 class="font-semibold">Rechnungen (legacy)</h4>
+    <app-generic-table [columns]="columns" [dataSource]="dataSource"></app-generic-table>
+  </div>
+}

--- a/src/app/components/order-display/legacy-invoice-display/legacy-invoice-display.component.spec.ts
+++ b/src/app/components/order-display/legacy-invoice-display/legacy-invoice-display.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LegacyInvoiceDisplayComponent } from './legacy-invoice-display.component';
+
+describe('LegacyInvoiceDisplayComponent', () => {
+  let component: LegacyInvoiceDisplayComponent;
+  let fixture: ComponentFixture<LegacyInvoiceDisplayComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LegacyInvoiceDisplayComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LegacyInvoiceDisplayComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/order-display/legacy-invoice-display/legacy-invoice-display.component.ts
+++ b/src/app/components/order-display/legacy-invoice-display/legacy-invoice-display.component.ts
@@ -1,0 +1,63 @@
+import { DataSource } from '@angular/cdk/table';
+import { Component, input, OnChanges, OnInit, signal } from '@angular/core';
+import { MatTableDataSource } from '@angular/material/table';
+import { InvoiceResponseDTO, OrderResponseDTO } from '../../../api-services-v2';
+import { INVOICE_FIELD_NAMES } from '../../../display-name-mappings/invoice-names';
+import { TableColumn } from '../../../models/generic-table';
+import { OrderSubresourceResolverService } from '../../../services/order-subresource-resolver.service';
+import { InvoicesWrapperServiceService } from '../../../services/wrapper-services/invoices-wrapper-service.service';
+import { GenericTableComponent } from '../../generic-table/generic-table.component';
+
+type LegacyInvoiceDisplayData = Omit<InvoiceResponseDTO, 'price'> & {
+  price: number | string;
+};
+
+@Component({
+  selector: 'app-legacy-invoice-display',
+  imports: [GenericTableComponent],
+  templateUrl: './legacy-invoice-display.component.html',
+  styleUrl: './legacy-invoice-display.component.scss',
+})
+export class LegacyInvoiceDisplayComponent implements OnInit, OnChanges {
+  order = input.required<OrderResponseDTO>();
+  columns: TableColumn<LegacyInvoiceDisplayData>[] = [
+    { id: 'id', label: INVOICE_FIELD_NAMES.id },
+    { id: 'comment', label: INVOICE_FIELD_NAMES.comment },
+    { id: 'cost_center_id', label: INVOICE_FIELD_NAMES.cost_center_id },
+    { id: 'price', label: INVOICE_FIELD_NAMES.price },
+    { id: 'date', label: INVOICE_FIELD_NAMES.date },
+    { id: 'created_date', label: INVOICE_FIELD_NAMES.created_date },
+    { id: 'order_id', label: INVOICE_FIELD_NAMES.order_id },
+  ];
+  dataSource: DataSource<LegacyInvoiceDisplayData> =
+    new MatTableDataSource<LegacyInvoiceDisplayData>([]);
+  isInitialized = false;
+  isEmpty = signal(true);
+
+  constructor(
+    private readonly invoiceService: InvoicesWrapperServiceService,
+    private readonly resourceResolver: OrderSubresourceResolverService
+  ) {}
+
+  ngOnInit() {
+    this.setupDataSource();
+    this.isInitialized = true;
+  }
+  ngOnChanges() {
+    if (this.isInitialized) {
+      this.setupDataSource();
+    }
+  }
+  setupDataSource() {
+    this.invoiceService.getLegacyInvoicesByOrderId(this.order().id!).subscribe(invoices => {
+      const formattedInvoices = invoices.map(invoice => ({
+        ...invoice,
+        price:
+          this.resourceResolver.formatPrice(invoice.price, this.order().currency?.code ?? 'EUR') ??
+          'Unbekannt',
+      }));
+      this.dataSource = new MatTableDataSource<LegacyInvoiceDisplayData>(formattedInvoices);
+      this.isEmpty.set(formattedInvoices.length <= 0);
+    });
+  }
+}

--- a/src/app/pages/order/view-order-page/view-order-page.component.html
+++ b/src/app/pages/order/view-order-page/view-order-page.component.html
@@ -152,7 +152,10 @@
           }
 
           @case ('documents') {
-            <app-order-documents [order]="internalOrder().order" />
+            <div class="flex flex-col gap-8">
+              <app-order-documents [order]="internalOrder().order" />
+              <app-legacy-invoice-display [order]="internalOrder().order" />
+            </div>
           }
 
           @case ('contacts') {

--- a/src/app/pages/order/view-order-page/view-order-page.component.ts
+++ b/src/app/pages/order/view-order-page/view-order-page.component.ts
@@ -83,6 +83,7 @@ import { UsersWrapperService } from '../../../services/wrapper-services/users-wr
 
 import { Title } from '@angular/platform-browser';
 import { finalize, from } from 'rxjs';
+import { LegacyInvoiceDisplayComponent } from '../../../components/order-display/legacy-invoice-display/legacy-invoice-display.component';
 import { ToastProcessingIndicatorComponent } from '../../../components/toast-processing-indicator/toast-processing-indicator.component';
 import { MailTrackingService } from '../../../services/mail-tracking.service';
 import { UtilsService } from '../../../services/utils.service';
@@ -146,6 +147,7 @@ interface StateChangeButtons {
     OrderMainQuoteComponent,
     OrderArticleListComponent,
     OrderAddressesComponent,
+    LegacyInvoiceDisplayComponent,
   ],
 
   templateUrl: './view-order-page.component.html',
@@ -221,7 +223,7 @@ export class ViewOrderPageComponent implements OnInit {
     private readonly mailTrackingService: MailTrackingService,
     private readonly utilsService: UtilsService,
     private readonly titleService: Title
-  ) { }
+  ) {}
 
   /**
    * Initializes the component, fetching necessary data and setting up state transitions.
@@ -259,7 +261,9 @@ export class ViewOrderPageComponent implements OnInit {
       });
     }
 
-    this.titleService.setTitle(`Bestellung ${this.internalOrder().orderDisplay.besy_number} ansehen`);
+    this.titleService.setTitle(
+      `Bestellung ${this.internalOrder().orderDisplay.besy_number} ansehen`
+    );
   }
 
   /**
@@ -306,9 +310,11 @@ export class ViewOrderPageComponent implements OnInit {
 
           this.snackBar.open('Bestellung erfolgreich exportiert.', 'Schließen', { duration: 5000 });
         },
-        error: err => {
-          this.snackBar.open('Bestellung konnte nicht exportiert werden.', 'Schließen', { duration: 5000 });
-        }
+        error: () => {
+          this.snackBar.open('Bestellung konnte nicht exportiert werden.', 'Schließen', {
+            duration: 5000,
+          });
+        },
       });
   }
 
@@ -348,7 +354,10 @@ export class ViewOrderPageComponent implements OnInit {
         style = 'outlined';
       }
 
-      if (state === OrderStatus.APPROVED && this.internalOrder().order.status === OrderStatus.DEKAN_PENDING) {
+      if (
+        state === OrderStatus.APPROVED &&
+        this.internalOrder().order.status === OrderStatus.DEKAN_PENDING
+      ) {
         color = 'accent';
       }
 
@@ -357,7 +366,9 @@ export class ViewOrderPageComponent implements OnInit {
       this.stateChangeButtons.push({
         label: this.isSkipApprovalStateChange(state) ? label + ' (überspringen)' : label,
         icon: STATE_ICONS.get(state) ?? '',
-        tooltip: this.isSkipApprovalStateChange(state) ? 'Genehmigung durch das Dekanat überspringen.' : STATE_CHANGE_TO_DESCRIPTIONS.get(state) ?? '',
+        tooltip: this.isSkipApprovalStateChange(state)
+          ? 'Genehmigung durch das Dekanat überspringen.'
+          : (STATE_CHANGE_TO_DESCRIPTIONS.get(state) ?? ''),
         state,
         color,
         style,
@@ -377,8 +388,7 @@ export class ViewOrderPageComponent implements OnInit {
 
   private isSkipApprovalStateChange(state: OrderStatus): boolean {
     return (
-      this.internalOrder().order.status === OrderStatus.COMPLETED &&
-      state === OrderStatus.APPROVED
+      this.internalOrder().order.status === OrderStatus.COMPLETED && state === OrderStatus.APPROVED
     );
   }
 
@@ -490,8 +500,7 @@ export class ViewOrderPageComponent implements OnInit {
     const data = {
       title: 'Bestellung wirklich löschen?',
 
-      description:
-        'Die Bestellung wird gelöscht, kann aber wiederhergestellt werden.',
+      description: 'Die Bestellung wird gelöscht, kann aber wiederhergestellt werden.',
 
       cancelButtonText: 'Abbrechen',
 

--- a/src/app/services/wrapper-services/invoices-wrapper-service.service.ts
+++ b/src/app/services/wrapper-services/invoices-wrapper-service.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
-import { from, mergeMap, Observable } from 'rxjs';
+import { from, map, mergeMap, Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
 import {
   InvoiceRequestDTO,
   InvoiceResponseDTO,
@@ -19,6 +20,36 @@ export class InvoicesWrapperServiceService {
   ) {}
 
   getDocumentsByOrderId(orderId: number) {
+    return this.ordersService
+      .getInvoicesOfOrder(orderId)
+      .pipe(
+        map(invoices =>
+          invoices.filter(
+            invoice =>
+              invoice.paperless_id != null ||
+              Date.parse(invoice.created_date ?? '') >=
+                environment.invoicesLegacyCutoffDate.getTime()
+          )
+        )
+      );
+  }
+
+  getLegacyInvoicesByOrderId(orderId: number) {
+    return this.ordersService
+      .getInvoicesOfOrder(orderId)
+      .pipe(
+        map(invoices =>
+          invoices.filter(
+            invoice =>
+              invoice.paperless_id == null &&
+              Date.parse(invoice.created_date ?? '') <
+                environment.invoicesLegacyCutoffDate.getTime()
+          )
+        )
+      );
+  }
+
+  getAllDocumentsByOrderId(orderId: number) {
     return this.ordersService.getInvoicesOfOrder(orderId);
   }
 

--- a/src/environments/environment.deployment.ts
+++ b/src/environments/environment.deployment.ts
@@ -36,4 +36,6 @@ export const environment = {
   wrappedUrl: '/wrap',
 
   showFooter: false,
+
+  invoicesLegacyCutoffDate: new Date('2026-01-01T00:00:00Z'),
 };

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -36,4 +36,6 @@ export const environment = {
   wrappedUrl: '/wrap',
 
   showFooter: true,
+
+  invoicesLegacyCutoffDate: new Date('2026-01-01T00:00:00Z'),
 };

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -36,4 +36,6 @@ export const environment = {
   wrappedUrl: '/wrap',
 
   showFooter: true,
+
+  invoicesLegacyCutoffDate: new Date('2026-01-01T00:00:00Z'),
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -36,4 +36,6 @@ export const environment = {
   wrappedUrl: '/wrap',
 
   showFooter: true,
+
+  invoicesLegacyCutoffDate: new Date('2026-01-01T00:00:00Z'),
 };


### PR DESCRIPTION
This pull request introduces a new component for displaying legacy invoices associated with an order, updates the logic for fetching invoices to distinguish between legacy and non-legacy documents, and integrates the new display into the order view page. It also adds a cutoff date configuration for legacy invoices and includes minor code style improvements.

### Legacy Invoice Display Feature

* Added the new `LegacyInvoiceDisplayComponent` to show legacy invoices in a table format, including its template, TypeScript logic, and a basic test. The component fetches legacy invoices based on a cutoff date and formats their display. [[1]](diffhunk://#diff-d8edbaf499faa5d59276edb0f8fba519eb074472c6869dbddc0f7b448ac03875R1-R63) [[2]](diffhunk://#diff-4be6b7156a5d0ace8b1a888aa4efea895dbd40ba0e8da52c8af620e5ce6dd1edR1-R6) [[3]](diffhunk://#diff-5afe230b74a161d7875659338b56532ddae5741b628e3e2ba41aab514e04f7f3R1-R22)
* Integrated `LegacyInvoiceDisplayComponent` into the order documents section of the order view page, ensuring legacy invoices are visible alongside other documents. [[1]](diffhunk://#diff-fae202d39cc31359256a20e902a3f773e1cb30d7ba410ff0a46e857552ab51aaR155-R158) [[2]](diffhunk://#diff-d031c76453131796e01feefa3a91505cff575a5d67abe024489f53c62ac81449R86) [[3]](diffhunk://#diff-d031c76453131796e01feefa3a91505cff575a5d67abe024489f53c62ac81449R150)

### Invoice Service Enhancements

* Updated `InvoicesWrapperServiceService` to add `getLegacyInvoicesByOrderId` and improved filtering logic for legacy/non-legacy invoices using a new cutoff date from the environment configuration. [[1]](diffhunk://#diff-190efa22076f45dda4cb933e7d9ae9b40d416d5bd1028ca4cc97a4932bb79210L2-R3) [[2]](diffhunk://#diff-190efa22076f45dda4cb933e7d9ae9b40d416d5bd1028ca4cc97a4932bb79210R23-R52)

### Environment Configuration

* Added `invoicesLegacyCutoffDate` to all environment files to configure the cutoff date for legacy invoice logic. [[1]](diffhunk://#diff-8dbc4bb62588387ed0464463f810cb5a1fb70a53c05b9c4850eeba30e8e32804R39-R40) [[2]](diffhunk://#diff-a8781811a71ccc5e6e8919aa7054cf3a9c66d8624b4687cb9029aa12a5b93049R39-R40) [[3]](diffhunk://#diff-39804702198d65620a37116408a2cd84a5fa3648985159c145d1bba74d5b65d5R39-R40) [[4]](diffhunk://#diff-d897f7d114ca657c43905bff9a6ee17e53e2d1ccc172b7c258a54183653a691aR39-R40)

### Code Style and Minor Improvements

* Made several formatting and style improvements in `ViewOrderPageComponent`, such as improving readability in conditional statements, error handling, and string formatting. [[1]](diffhunk://#diff-d031c76453131796e01feefa3a91505cff575a5d67abe024489f53c62ac81449L262-R266) [[2]](diffhunk://#diff-d031c76453131796e01feefa3a91505cff575a5d67abe024489f53c62ac81449L309-R317) [[3]](diffhunk://#diff-d031c76453131796e01feefa3a91505cff575a5d67abe024489f53c62ac81449L351-R360) [[4]](diffhunk://#diff-d031c76453131796e01feefa3a91505cff575a5d67abe024489f53c62ac81449L360-R371) [[5]](diffhunk://#diff-d031c76453131796e01feefa3a91505cff575a5d67abe024489f53c62ac81449L380-R391) [[6]](diffhunk://#diff-d031c76453131796e01feefa3a91505cff575a5d67abe024489f53c62ac81449L493-R503)