### PR TITLE
Store updated approvals after patching in EditOrderPageComponent

### DIFF
--- a/src/app/pages/order/edit-order-page/edit-order-page.component.ts
+++ b/src/app/pages/order/edit-order-page/edit-order-page.component.ts
@@ -1971,7 +1971,8 @@ export class EditOrderPageComponent implements OnInit, HasUnsavedChanges, OnDest
     this.additionalChangesMade = this.additionalChangesMade || true;
     // Send the approval patch to the backend
     try {
-      await this.orderWrapperService.patchOrderApprovals(this.editOrderId, changedApprovalFields);
+      const approvalsAfterPatch = await this.orderWrapperService.patchOrderApprovals(this.editOrderId, changedApprovalFields);
+      this.unmodifiedApprovals = approvalsAfterPatch;
       this._notifications.open('Zustimmungen wurden erfolgreich gespeichert.', undefined, {
         duration: 3000,
       });


### PR DESCRIPTION
This pull request updates the approval patch workflow in the `EditOrderPageComponent` to improve state management after saving changes. Now, after patching order approvals, the component updates its local state to reflect the latest approvals from the backend.

**Order approval workflow improvements:**

* After calling `patchOrderApprovals`, the returned approvals are now assigned to `this.unmodifiedApprovals`, ensuring the component state matches the backend after changes are saved.