### PR TITLE
Handle null auto_index in order number

### DIFF
--- a/src/app/services/order-subresource-resolver.service.ts
+++ b/src/app/services/order-subresource-resolver.service.ts
@@ -321,7 +321,7 @@ export class OrderSubresourceResolverService {
    */
   getOrderNumber(order: OrderResponseDTO): string | undefined {
     const formattedIndex =
-      order.auto_index !== undefined ? order.auto_index.toString().padStart(3, '0') : undefined;
+      order.auto_index != undefined ? order.auto_index.toString().padStart(3, '0') : undefined;
     const orderNumber = [order.primary_cost_center_id, order.booking_year, formattedIndex];
     if (orderNumber.some(part => part === undefined || part === null || part === '')) {
       return undefined;


### PR DESCRIPTION
Treat null and undefined the same when formatting order.auto_index so we don't call toString on null. Replaced strict !== undefined with != undefined to avoid runtime errors when auto_index can be null while building the order number.