### PR TITLE
Remove sample tracking data

### DIFF
--- a/src/app/services/user-wrap.service.ts
+++ b/src/app/services/user-wrap.service.ts
@@ -90,12 +90,7 @@ export class UserWrapService {
   private readonly destroyRef = inject(DestroyRef);
 
   private sampleOrders: OrderSnapshot[] | undefined;
-  private engagementSamples: TrackingData[] | undefined = [
-    // Sample data for testing
-    { year: 2024, requests: 150, errors: 5, totalTime: 120000 },
-    { year: 2025, requests: 200, errors: 10, totalTime: 180000 },
-    { year: 2026, requests: 250, errors: 8, totalTime: 70 * 60 * 1000 },
-  ];
+  private engagementSamples: TrackingData[] | undefined = undefined;
 
   constructor(
     private readonly ordersService: OrdersWrapperService,
@@ -168,7 +163,7 @@ export class UserWrapService {
     return Math.round(
       (new Date(history.at(-1)!.timestamp!).getTime() -
         new Date(history.at(0)!.timestamp!).getTime()) /
-        (1000 * 60 * 60 * 24)
+      (1000 * 60 * 60 * 24)
     ); // days
   }
 

--- a/src/app/services/user-wrap.service.ts
+++ b/src/app/services/user-wrap.service.ts
@@ -90,7 +90,7 @@ export class UserWrapService {
   private readonly destroyRef = inject(DestroyRef);
 
   private sampleOrders: OrderSnapshot[] | undefined;
-  private engagementSamples: TrackingData[] | undefined = undefined;
+  private engagementSamples: TrackingData[] | undefined;
 
   constructor(
     private readonly ordersService: OrdersWrapperService,

--- a/src/app/services/user-wrap.service.ts
+++ b/src/app/services/user-wrap.service.ts
@@ -470,6 +470,9 @@ export class UserWrapService {
     return this.trackingService.getTrackingData().pipe(
       tap(samples => {
         this.engagementSamples = samples;
+      }),
+      catchError(() => {
+        console.error('Failed to load tracking data for wrap metrics'); return of([] as TrackingData[]);
       })
     );
   }

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -10,8 +10,8 @@ export const environment = {
   bugReportUrl: 'https://github.com/BeSy-Rewrite/BeSy-Frontend/issues/new/choose',
 
   // Keycloak configuration
-  identityProviderUrl: 'https://auth.insy.hs-esslingen.com/realms/insy',
-  clientId: 'besy-dev',
+  identityProviderUrl: 'https://auth.dev.hs-esslingen.com/realms/besy',
+  clientId: 'dev-localhost',
   requiredRole: 'orderer',
   approveOrdersRole: 'approver',
 


### PR DESCRIPTION
This pull request makes two main changes: it updates the Keycloak identity provider configuration for the development environment and removes hardcoded sample engagement data from the `UserWrapService`. These changes improve security and ensure the code does not rely on test data in production.

**Environment configuration changes:**
* Updated the Keycloak `identityProviderUrl` and `clientId` in `environment.development.ts` to use the correct development realm and client, replacing the old INSY values with the new BESY development values.

**Code cleanup:**
* Removed hardcoded sample engagement data from the `engagementSamples` property in `UserWrapService`, setting it to `undefined` instead.