### PR TITLE
Cancel toast before closing indicator

### DIFF
--- a/src/app/components/documents/document-upload/document-upload.component.ts
+++ b/src/app/components/documents/document-upload/document-upload.component.ts
@@ -205,7 +205,7 @@ export class DocumentUploadComponent implements OnInit {
     uploadObservable
       .pipe(
         finalize(() => {
-          this.toastRef?.cancel(true)
+          this.toastRef?.cancel(true);
           this.processingIndicator
             ?.afterClosed()
             .pipe(

--- a/src/app/components/documents/document-upload/document-upload.component.ts
+++ b/src/app/components/documents/document-upload/document-upload.component.ts
@@ -205,13 +205,14 @@ export class DocumentUploadComponent implements OnInit {
     uploadObservable
       .pipe(
         finalize(() => {
-          this.processingIndicator?.close();
+          this.toastRef?.cancel(true)
           this.processingIndicator
             ?.afterClosed()
             .pipe(
               debounceTime(50) // Loading indicator toast is created after closing the dialog, ensures it exists
             )
             .subscribe(() => this.toastRef?.cancel(true));
+          this.processingIndicator?.close();
         })
       )
       .subscribe({


### PR DESCRIPTION
Avoid a race where the loading toast can remain visible after the processing dialog is closed. Call toastRef?.cancel(true) immediately, keep the existing afterClosed debounce cancel to handle toasts created during dialog teardown, and then close the processingIndicator. This ensures the toast is reliably dismissed.